### PR TITLE
Add cancelOrder on modal close

### DIFF
--- a/assets/scripts/events.js
+++ b/assets/scripts/events.js
@@ -194,6 +194,9 @@ const addHandlers = () => {
   $('#get-orders').on('click', onGetHistory)
   $('#cart-button').on('click', function () { $('#order-history').html('') })
   $('#cart-button').on('click', function () { $('#history-message').html('') })
+  $('#cart-button').on('click', function () { $('#cart-message').html('') })
+  $('#cart').on('hidden.bs.modal', function () { if (store.cart) { onCancelOrder() } })
+  $('.cart-btn').on('click', function () { $('#checkout').removeClass('hide') })
   // ---------------------- CUSTOM STRIPE INTEGRATION HANDLERS -------------------------
   $('#purchase').on('click', (event) => {
     event.preventDefault()

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -68,8 +68,8 @@ const signOutFailure = function () {
 const checkoutSuccess = function (data) {
   store.cart = data.cart
   $('.cart-button').removeClass('hide')
-  $('#checkout').hide()
-  $('#cart-message').text('Select "Update", "Cancel", or "Purchase" to proceed').css('color', 'green')
+  $('#checkout').addClass('hide')
+  $('#cart-message').text('Select "Cancel" or "Purchase" to proceed').css('color', 'green')
 }
 
 const checkoutFailure = function () {
@@ -77,7 +77,7 @@ const checkoutFailure = function () {
 }
 
 const updateOrderSuccess = function () {
-  $('#cart-message').text('Order successfully updated!').css('color', 'green')
+  $('#cart-message').text('Purchase successful!').css('color', 'green')
   $('#cart-total').trigger('reset')
   $('#checkout').addClass('hide')
   $('.cart-btn').removeClass('hide')
@@ -95,7 +95,10 @@ const cancelOrderSuccess = function () {
   $('.cart-item').remove()
   // message indicating success
   $('.cart-button').addClass('hide')
-  $('#checkout').show()
+  $('#cart-message').text('Order canceled').css('color', 'green')
+  $('#cart-total').trigger('reset')
+  $('.cart-btn').removeClass('hide')
+  $('.add-to-cart').text('')
 }
 
 const cancelOrderFailure = function () {


### PR DESCRIPTION
After pressing checkout, if modal closes for any reason (connectivity,
clicks, accident, sign out), order is deleted.

Paired with @RasyadiAbdoellah